### PR TITLE
NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement.

### DIFF
--- a/prawn-svg.gemspec
+++ b/prawn-svg.gemspec
@@ -6,7 +6,6 @@ spec = Gem::Specification.new do |gem|
   gem.version = Prawn::Svg::VERSION
   gem.summary = "SVG renderer for Prawn PDF library"
   gem.description = "This gem allows you to render SVG directly into a PDF using the 'prawn' gem.  Since PDF is vector-based, you'll get nice scaled graphics if you use SVG instead of an image."
-  gem.has_rdoc = false
   gem.author = "Roger Nesbitt"
   gem.email = "roger@seriousorange.com"
   gem.homepage = "http://github.com/mogest/prawn-svg"


### PR DESCRIPTION
# About

While upgrading ruby:

NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2018-12-01.